### PR TITLE
Share flashcard manager across home and library

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -18,13 +18,36 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   int _current = 0;
+  late final FlashcardManager _flashcardManager;
+  late final List<Widget> _pages;
 
-  late final _pages = [
-    const _HomeBody(),
-    ExplorePage(),
-    LibraryPage(),
-    ProfilePage(),
-  ];
+  @override
+  void initState() {
+    super.initState();
+    _flashcardManager = FlashcardManager.demo();
+    _pages = [
+      _HomeBody(onCreateFlashcards: _handleCreateFlashcards),
+      ExplorePage(),
+      LibraryPage(manager: _flashcardManager),
+      ProfilePage(),
+    ];
+  }
+
+  Future<void> _handleCreateFlashcards() async {
+    final result = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => CreateFlashcardsPage(
+          manager: _flashcardManager,
+        ),
+      ),
+    );
+
+    if (!mounted) return;
+    if (result != null) {
+      setState(() => _current = 2);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -57,7 +80,9 @@ class _HomePageState extends State<HomePage> {
 //
 
 class _HomeBody extends StatelessWidget {
-  const _HomeBody();
+  const _HomeBody({required this.onCreateFlashcards});
+
+  final Future<void> Function() onCreateFlashcards;
 
   @override
   Widget build(BuildContext context) {
@@ -194,14 +219,7 @@ class _HomeBody extends StatelessWidget {
                     title: 'Create flashcards',
                     subtitle: 'without AI for free',
                     onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => CreateFlashcardsPage(
-                            manager: FlashcardManager.demo(),
-                          ),
-                        ),
-                      );
+                      onCreateFlashcards();
                       debugPrint("Create flashcards tapped");
                     },
                   ),

--- a/lib/pages/library/flashcards_tab.dart
+++ b/lib/pages/library/flashcards_tab.dart
@@ -1,210 +1,103 @@
 import 'package:flutter/material.dart';
+import 'package:study_application/manager/flashcard_manager.dart';
+import 'package:study_application/model/flashcard.dart';
 
 /// -------------------- PAGE --------------------
-class FlashcardsTab extends StatefulWidget {
-  const FlashcardsTab({super.key});
+class FlashcardsTab extends StatelessWidget {
+  const FlashcardsTab({super.key, required this.manager});
 
-  @override
-  State<FlashcardsTab> createState() => _FlashcardsTabState();
-}
-
-class _FlashcardsTabState extends State<FlashcardsTab> {
-  // Mock data
-  late final List<FlashcardSet> _all = [
-    FlashcardSet(
-      title: 'Cell Membranes',
-      count: 20,
-      subject: 'Microbiology',
-      category: 'Biology',
-    ),
-    FlashcardSet(
-      title: 'Software Development Lifecycle',
-      count: 25,
-      subject: 'Computer Science',
-      category: 'Computer Science',
-    ),
-    FlashcardSet(
-      title: 'Digital Logic Design',
-      count: 15,
-      subject: 'Engineering Technique',
-      category: 'Engineering',
-    ),
-    FlashcardSet(
-      title: 'Algebraic Structures',
-      count: 30,
-      subject: 'Mathematics for Dummies',
-      category: 'Mathematics',
-    ),
-  ];
+  final FlashcardManager manager;
 
   @override
   Widget build(BuildContext context) {
-    final data = _all;
+    return AnimatedBuilder(
+      animation: manager,
+      builder: (context, _) {
+        final cards = manager.all;
+        if (cards.isEmpty) {
+          return const _EmptyFlashcards();
+        }
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        // List flashcards
-        Expanded(
-          child: ListView.separated(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            itemCount: data.length,
-            separatorBuilder: (_, __) => const SizedBox(height: 12),
-            itemBuilder: (_, i) => FlashcardSetCard(
-              item: data[i],
-              onMore: () {},
-              onTap: () {},
-            ),
-          ),
-        ),
-      ],
+        return ListView.separated(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          itemCount: cards.length,
+          separatorBuilder: (_, __) => const SizedBox(height: 12),
+          itemBuilder: (_, i) => _FlashcardCard(card: cards[i]),
+        );
+      },
     );
   }
 }
 
-/// -------------------- MODEL --------------------
-class FlashcardSet {
-  final String title;
-  final int count;
-  final String subject;
-  final String category;
-  FlashcardSet({
-    required this.title,
-    required this.count,
-    required this.subject,
-    required this.category,
-  });
-}
-
-/// -------------------- CARD --------------------
-class FlashcardSetCard extends StatelessWidget {
-  final FlashcardSet item;
-  final VoidCallback? onTap;
-  final VoidCallback? onMore;
-
-  const FlashcardSetCard({
-    super.key,
-    required this.item,
-    this.onTap,
-    this.onMore,
-  });
-
-  static const String _kFlashIcon = 'assets/icons/flash-card.png';
+class _EmptyFlashcards extends StatelessWidget {
+  const _EmptyFlashcards();
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      borderRadius: BorderRadius.circular(16),
-      onTap: onTap,
-      child: Ink(
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: const Color(0xFFE9ECF3)),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.04),
-              blurRadius: 14,
-              offset: const Offset(0, 8),
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            Icon(Icons.style_outlined, size: 48, color: Colors.black26),
+            SizedBox(height: 12),
+            Text(
+              'No flashcards yet. Create some to see them here.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontWeight: FontWeight.w600,
+                color: Colors.black54,
+              ),
             ),
           ],
         ),
-        child: Padding(
-          padding: const EdgeInsets.all(14),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Hàng đầu: icon PNG + tiêu đề + globe + more
-              Row(
-                children: [
-                  _leadingPng(_kFlashIcon),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Text(
-                      item.title,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        fontWeight: FontWeight.w800,
-                        fontSize: 16,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                ],
-              ),
-
-              const SizedBox(height: 6),
-
-              // Meta: "20 flashcards · from Microbiology"
-              Text(
-                '${item.count} flashcards  ·  from ${item.subject}',
-                style: TextStyle(
-                  color: Colors.grey.shade600,
-                  fontSize: 12,
-                ),
-              ),
-
-              const SizedBox(height: 12),
-              const Divider(height: 1, thickness: 1, color: Color(0xFFEFF1F5)),
-              const SizedBox(height: 10),
-
-              // Dòng dưới: category chip
-              Row(
-                children: [
-                  _categoryChip(item.category),
-                  const Spacer(),
-                  const Icon(Icons.public, size: 18, color: Colors.black54),
-                  const SizedBox(width: 6),
-                  GestureDetector(
-                    onTap: onMore,
-                    child: const Icon(Icons.more_vert,
-                        size: 18, color: Colors.black54),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
       ),
     );
   }
+}
 
-  // Icon PNG chung (bao trong khung mềm đồng bộ style)
-  Widget _leadingPng(String asset) {
+class _FlashcardCard extends StatelessWidget {
+  const _FlashcardCard({required this.card});
+
+  final Flashcard card;
+
+  @override
+  Widget build(BuildContext context) {
     return Container(
-      height: 28,
-      width: 28,
       decoration: BoxDecoration(
-        color: const Color(0xFFF6F7FB),
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: const Color(0xFFE7E9F0)),
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: const Color(0xFFE9ECF3)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 14,
+            offset: const Offset(0, 8),
+          ),
+        ],
       ),
       child: Padding(
-        padding: const EdgeInsets.all(4),
-        child: Image.asset(
-          asset,
-          fit: BoxFit.contain,
-        ),
-      ),
-    );
-  }
-
-  // Soft category chip (e.g., "Biology")
-  Widget _categoryChip(String label) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        color: const Color(0xFFF6F7FB),
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: const Color(0xFFE7E9F0)),
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          fontSize: 12,
-          color: Colors.grey.shade800,
-          fontWeight: FontWeight.w700,
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              card.term,
+              style: const TextStyle(
+                fontWeight: FontWeight.w800,
+                fontSize: 16,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              card.definition,
+              style: TextStyle(
+                color: Colors.grey.shade700,
+                fontSize: 14,
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/pages/library/library_page.dart
+++ b/lib/pages/library/library_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:study_application/manager/flashcard_manager.dart';
 import 'package:study_application/manager/studysets_manager.dart';
 import 'package:study_application/model/study_set.dart'; // Thay thế StudySetItem bằng StudySet
 import 'package:study_application/pages/library/explanations_tab.dart';
@@ -8,8 +9,14 @@ import 'package:study_application/utils/color.dart'; // AppColors.randomAccent()
 
 /// ====================== PUBLIC PAGE ======================
 class LibraryPage extends StatefulWidget {
-  const LibraryPage({super.key, this.onTabChanged, this.onSearch});
+  const LibraryPage({
+    super.key,
+    required this.manager,
+    this.onTabChanged,
+    this.onSearch,
+  });
 
+  final FlashcardManager manager;
   final ValueChanged<LibraryTab>? onTabChanged;
   final ValueChanged<String>? onSearch;
 
@@ -99,7 +106,7 @@ class _LibraryPageState extends State<LibraryPage> {
         );
 
       case LibraryTab.flashcards:
-        return const FlashcardsTab();
+        return FlashcardsTab(manager: widget.manager);
 
       case LibraryTab.explanations:
         return ExplanationsTab();


### PR DESCRIPTION
## Summary
- instantiate a single FlashcardManager in HomePage state and reuse it across tabs
- pass the shared manager into LibraryPage and use it when launching flashcard creation
- rebuild the library flashcard tab to listen to the shared manager and render created cards

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd40fe6b4c832f8a3c11b408204497